### PR TITLE
Update README.md (no more CC icons)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,4 @@ Example:
 	});
 
 ## License
-Code is licensed under Apache 2.0. Icons are under Creative Commons 3.0.
-Icons are from http://www.fatcow.com/free-icons
+Code is licensed under Apache 2.0.


### PR DESCRIPTION
Latest commit @c0ba6fb doesn't contain CC licensed icons. Portion of README.md related to icons is redundant now and should be removed.