### PR TITLE
Vaadin 7 Java 1.7, focus on value change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - .gradle
 
 jdk:
-  - oraclejdk8
+  - openjdk7
 
 script:
   - ./gradlew sonarqube

--- a/addon/src/main/java/org/vaadin/risto/stepper/AbstractStepper.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/AbstractStepper.java
@@ -124,6 +124,10 @@ public abstract class AbstractStepper<T, S> extends AbstractField<T>
         getState().isNullValueAllowed = nullValueAllowed;
     }
 
+    /**
+     * Enable / disable focusing on value change
+     * @param focusOnValueChange if true, focus the editor field on value change
+     */
     public void setFocusOnValueChange(boolean focusOnValueChange) {
         getState().isFocusOnValueChange = focusOnValueChange;
     }

--- a/addon/src/main/java/org/vaadin/risto/stepper/AbstractStepper.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/AbstractStepper.java
@@ -124,6 +124,10 @@ public abstract class AbstractStepper<T, S> extends AbstractField<T>
         getState().isNullValueAllowed = nullValueAllowed;
     }
 
+    public void setFocusOnValueChange(boolean focusOnValueChange) {
+        getState().isFocusOnValueChange = focusOnValueChange;
+    }
+
     @Override
     public void beforeClientResponse(boolean initial) {
         super.beforeClientResponse(initial);

--- a/addon/src/main/java/org/vaadin/risto/stepper/AbstractStepper.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/AbstractStepper.java
@@ -296,8 +296,6 @@ public abstract class AbstractStepper<T, S> extends AbstractField<T>
         }
     }
 
-
-    @FunctionalInterface
     /**
      * Implement this interface to create a click listener for a Stepper.
      */

--- a/addon/src/main/java/org/vaadin/risto/stepper/client/shared/AbstractStepperConnector.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/client/shared/AbstractStepperConnector.java
@@ -53,7 +53,7 @@ public abstract class AbstractStepperConnector<T, S>
         getWidget().setMouseWheelEnabled(getState().isMouseWheelEnabled);
         getWidget().setInvalidValuesAllowed(getState().isInvalidValuesAllowed);
         getWidget().setNullValueAllowed(getState().isNullValueAllowed);
-
+        getWidget().setFocusOnValueChange(getState().isFocusOnValueChange);
         getWidget()
                 .setMinValue(getWidget().parseStringValue(getState().minValue));
         getWidget()

--- a/addon/src/main/java/org/vaadin/risto/stepper/client/shared/AbstractStepperState.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/client/shared/AbstractStepperState.java
@@ -13,6 +13,7 @@ public class AbstractStepperState extends AbstractFieldState {
     public boolean isMouseWheelEnabled = true;
     public boolean isInvalidValuesAllowed = false;
     public boolean isNullValueAllowed = false;
+    public boolean isFocusOnValueChange = false;
     public String value;
     public String minValue;
     public String maxValue;

--- a/addon/src/main/java/org/vaadin/risto/stepper/client/shared/ClickRpc.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/client/shared/ClickRpc.java
@@ -3,7 +3,6 @@ package org.vaadin.risto.stepper.client.shared;
 import com.vaadin.shared.MouseEventDetails;
 import com.vaadin.shared.communication.ServerRpc;
 
-@FunctionalInterface
 /**
  * Server RPC that is called when the stepper is clicked
  */

--- a/addon/src/main/java/org/vaadin/risto/stepper/client/ui/AbstractStepper.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/client/ui/AbstractStepper.java
@@ -17,8 +17,6 @@ import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.TextBox;
 
-import java.util.logging.Handler;
-
 /**
  * 
  * @author Risto Yrjänä / Vaadin
@@ -62,6 +60,8 @@ public abstract class AbstractStepper<T, S> extends FlowPanel
     private RegExp valueRegexp;
 
     private boolean isValueFilteringEnabled;
+
+    private boolean focusOnValueChange = false;
 
     public AbstractStepper() {
         this(".*"); // match all by default
@@ -166,6 +166,9 @@ public abstract class AbstractStepper<T, S> extends FlowPanel
                     value = newValue;
                     valueUpdateTimer.schedule(updateDelay);
                     valueUpdateTimer.setValue(newValue);
+                    if (focusOnValueChange) {
+                        this.setFocus(true);
+                    }
                 }
             } catch (Exception e) {
                 valueUpdateTimer.cancel();
@@ -189,6 +192,9 @@ public abstract class AbstractStepper<T, S> extends FlowPanel
                     value = newValue;
                     valueUpdateTimer.schedule(updateDelay);
                     valueUpdateTimer.setValue(newValue);
+                    if (focusOnValueChange) {
+                        this.setFocus(true);
+                    }
                 }
             } catch (Exception e) {
                 valueUpdateTimer.cancel();
@@ -317,6 +323,10 @@ public abstract class AbstractStepper<T, S> extends FlowPanel
     public void setNullValueAllowed(boolean nullValueAllowed) {
         this.nullValueAllowed = nullValueAllowed;
         enabledStateChanged();
+    }
+
+    public void setFocusOnValueChange(boolean focusOnValueChange) {
+        this.focusOnValueChange = focusOnValueChange;
     }
 
     public boolean isNullValueAllowed() {

--- a/addon/src/main/java/org/vaadin/risto/stepper/client/ui/AbstractStepper.java
+++ b/addon/src/main/java/org/vaadin/risto/stepper/client/ui/AbstractStepper.java
@@ -325,6 +325,10 @@ public abstract class AbstractStepper<T, S> extends FlowPanel
         enabledStateChanged();
     }
 
+    /**
+     * Enable / disable focus on value change
+     * @param focusOnValueChange if true, focus editor widget on value change
+     */
     public void setFocusOnValueChange(boolean focusOnValueChange) {
         this.focusOnValueChange = focusOnValueChange;
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ subprojects {
         strict = true
     }
 
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+    sourceCompatibility = "1.7"
+    targetCompatibility = "1.7"
 
     group = "org.vaadin.risto.${baseNameLower}"
 

--- a/demo/src/main/java/org/vaadin/risto/stepper/demo/DemoUIProvider.java
+++ b/demo/src/main/java/org/vaadin/risto/stepper/demo/DemoUIProvider.java
@@ -15,7 +15,7 @@ public class DemoUIProvider extends UIProvider {
         String test = event.getRequest().getParameter("test");
 
         if (!Strings.isNullOrEmpty(test)
-                && CharMatcher.JAVA_LETTER.matchesAllOf(test)) {
+                /* doesn't work in 1.7: && CharMatcher.JAVA_LETTER.matchesAllOf(test)*/) {
             try {
                 @SuppressWarnings("unchecked")
                 Class<? extends UI> uiClass = (Class<? extends UI>) getClass()

--- a/demo/src/main/java/org/vaadin/risto/stepper/demo/StepperDemoUI.java
+++ b/demo/src/main/java/org/vaadin/risto/stepper/demo/StepperDemoUI.java
@@ -18,6 +18,7 @@ import com.vaadin.ui.Notification;
 import com.vaadin.ui.Panel;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
+import org.vaadin.risto.stepper.AbstractStepper;
 import org.vaadin.risto.stepper.BigDecimalStepper;
 import org.vaadin.risto.stepper.DateStepper;
 import org.vaadin.risto.stepper.FloatStepper;
@@ -142,7 +143,12 @@ public class StepperDemoUI extends UI {
         intStepper.setValue(1);
         intStepper.setStepAmount(1);
         intStepper.setCaption("IntStepper, step 1 (tabindex 3)");
-        intStepper.addClickListener(e -> Notification.show("clicked"));
+        intStepper.addClickListener(new AbstractStepper.StepperClickListener() {
+            @Override
+            public void stepperClick(AbstractStepper.StepperClickEvent event) {
+                Notification.show("clicked");
+            }
+        });
         intStepper.setTabIndex(3);
 
         floatStepper = new FloatStepper();

--- a/demo/src/main/java/org/vaadin/risto/stepper/demo/StepperDemoUI.java
+++ b/demo/src/main/java/org/vaadin/risto/stepper/demo/StepperDemoUI.java
@@ -150,6 +150,7 @@ public class StepperDemoUI extends UI {
             }
         });
         intStepper.setTabIndex(3);
+        intStepper.setFocusOnValueChange(true);
 
         floatStepper = new FloatStepper();
         floatStepper.setValue(1.0f);
@@ -157,6 +158,7 @@ public class StepperDemoUI extends UI {
         floatStepper.setNumberOfDecimals(3);
         floatStepper.setCaption("FloatStepper, step 1.222 (tabindex 2)");
         floatStepper.setTabIndex(2);
+        floatStepper.setFocusOnValueChange(true);
 
         bigDecimalStepper = new BigDecimalStepper();
         bigDecimalStepper.setValue(BigDecimal.ZERO);


### PR DESCRIPTION
Remove Java 1.8 features from Vaadin 7 version of Stepper. Add new `focusOnValueChange` flag which focuses the editor field when the value is changed with the buttons or mouse wheel.